### PR TITLE
Add toolchain file config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.pnpm-store/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
 
 This action will automatically install the appropriate toolchain with `rustup` by inspecting the
 `RUSTUP_TOOLCHAIN` environment variable or the `rust-toolchain.toml` (preferred) or `rust-toolchain`
-configuration files. If no toolchain found, will default to `stable`.
+configuration files. To specify the location of the toolchain configuration files you can use `rust-toolchain-file` option. If no toolchain found, will default to `stable`.
 
 ```toml
 # rust-toolchain.toml

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,8 @@ inputs:
   cache:
     description: 'Toggle caching of ~/.cargo/registry and /target/debug directories.'
     default: true
+  rust-toolchain-file:
+    description: 'Path to a rust-toolchain file to install.'
   channel:
     description: 'Toolchain specification/channel to install.'
   components:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Toggle caching of ~/.cargo/registry and /target/debug directories.'
     default: true
   rust-toolchain-file:
-    description: 'Path to a rust-toolchain file to install.'
+    description: 'Path to a rust-toolchain file.'
   channel:
     description: 'Toolchain specification/channel to install.'
   components:

--- a/src/rust.ts
+++ b/src/rust.ts
@@ -94,27 +94,27 @@ export function detectToolchain(): Toolchain {
 		});
 	} else {
 		core.info('Loading rust-toolchain.toml or rust-toolchain file');
-    const toolchainFile = core.getInput('rust-toolchain-file');
+		const toolchainFile = core.getInput('rust-toolchain-file');
 
-    if (toolchainFile) {
-      if (fs.existsSync(toolchainFile)) {
-        Object.assign(toolchain, parseConfig(toolchainFile));
-      } else {
-        core.setFailed('Not found toolchain config file');
-        throw new Error('Not found toolchain config file');
-      }
-    } else {
-      for (const configName of ['rust-toolchain.toml', 'rust-toolchain']) {
-        const configPath = path.join(process.cwd(), configName);
+		if (toolchainFile) {
+			if (fs.existsSync(toolchainFile)) {
+				Object.assign(toolchain, parseConfig(toolchainFile));
+			} else {
+				core.setFailed('Not found toolchain config file');
+				throw new Error('Not found toolchain config file');
+			}
+		} else {
+			for (const configName of ['rust-toolchain.toml', 'rust-toolchain']) {
+				const configPath = path.join(process.cwd(), configName);
 
-        if (fs.existsSync(configPath)) {
-          core.debug(`Found ${configName}, parsing TOML`);
+				if (fs.existsSync(configPath)) {
+					core.debug(`Found ${configName}, parsing TOML`);
 
-          Object.assign(toolchain, parseConfig(configPath));
-          break;
-        }
-      }
-    }
+					Object.assign(toolchain, parseConfig(configPath));
+					break;
+				}
+			}
+		}
 	}
 
 	core.info('Inheriting toolchain settings from inputs');

--- a/src/rust.ts
+++ b/src/rust.ts
@@ -94,17 +94,27 @@ export function detectToolchain(): Toolchain {
 		});
 	} else {
 		core.info('Loading rust-toolchain.toml or rust-toolchain file');
+    const toolchainFile = core.getInput('rust-toolchain-file');
 
-		for (const configName of ['rust-toolchain.toml', 'rust-toolchain']) {
-			const configPath = path.join(process.cwd(), configName);
+    if (toolchainFile) {
+      if (fs.existsSync(toolchainFile)) {
+        Object.assign(toolchain, parseConfig(toolchainFile));
+      } else {
+        core.setFailed('Not found toolchain config file');
+        throw new Error('Not found toolchain config file');
+      }
+    } else {
+      for (const configName of ['rust-toolchain.toml', 'rust-toolchain']) {
+        const configPath = path.join(process.cwd(), configName);
 
-			if (fs.existsSync(configPath)) {
-				core.debug(`Found ${configName}, parsing TOML`);
+        if (fs.existsSync(configPath)) {
+          core.debug(`Found ${configName}, parsing TOML`);
 
-				Object.assign(toolchain, parseConfig(configPath));
-				break;
-			}
-		}
+          Object.assign(toolchain, parseConfig(configPath));
+          break;
+        }
+      }
+    }
 	}
 
 	core.info('Inheriting toolchain settings from inputs');


### PR DESCRIPTION
This adds the possibility to add the path to the toolchain config file. This is needed if the rust project is in a different sub folder