### PR TITLE
build: bump Node from v16 to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ outputs:
   rust-hash:
     description: 'Commit hash of the installed rustc.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
   post: 'dist/post/index.js'
 branding:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "detect-libc": "^2.0.2"
   },
   "devDependencies": {
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.8.9",
     "@vercel/ncc": "^0.36.1",
     "eslint": "^8.46.0",
     "eslint-config-moon": "^2.0.6",
@@ -36,6 +36,6 @@
     "typescript": "^5.1.6"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@actions/cache':
     specifier: ^3.2.1
@@ -28,8 +32,8 @@ dependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^18.15.11
-    version: 18.15.11
+    specifier: ^20.8.9
+    version: 20.8.9
   '@vercel/ncc':
     specifier: ^0.36.1
     version: 0.36.1
@@ -382,6 +386,13 @@ packages:
 
   /@types/node@18.15.11:
     resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
+    dev: false
+
+  /@types/node@20.8.9:
+    resolution: {integrity: sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -2859,6 +2870,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /update-browserslist-db@1.0.11(browserslist@4.21.10):

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "tsconfig-moon/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
-    "module": "Node16",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "verbatimModuleSyntax": false


### PR DESCRIPTION
Node 16 [reached its EOL](https://nodejs.org/en/blog/announcements/nodejs16-eol), and GitHub Actions [will be deprecating it](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) in favor of v20 early next year.