### PR TITLE
Use GITHUB_WORKFLOW to generate cache key

### DIFF
--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -136,6 +136,13 @@ export async function getPrimaryCacheKey() {
 	core.debug(`Hashing target profile = ${cacheTarget}`);
 	hasher.update(cacheTarget);
 
+	const workflow = process.env.GITHUB_WORKFLOW;
+
+	if (workflow) {
+		core.debug(`Hashing GITHUB_WORKFLOW = ${workflow}`);
+		hasher.update(workflow);
+	}
+
 	const job = process.env.GITHUB_JOB;
 
 	if (job) {


### PR DESCRIPTION
While utilizing ["Reusable Workflows"](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow), using `GITHUB_JOB` env variable alone is not sufficient. Across all the child workflows which call a reusable workflow,`GITHUB_JOB` will contain the same name.

Since this pattern is often used in monorepos hosting multiple services or libraries with independent dependencies, cache should be generated per-workflow as well.

In typical use case of having completely separated workflow definitions, the cache is also guaranteed not to be shared across workflows (even if job ID is duplicated intentionally or by accident).