### PR TITLE
Update cache version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Miles Johnson",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.2.4",
+    "@actions/cache": "^4.0.0",
     "@actions/core": "^1.10.1",
     "@actions/exec": "^1.1.1",
     "@actions/glob": "^0.4.0",


### PR DESCRIPTION
Update cache version, due to the following [deprecation](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes).