### PR TITLE
feat: Add cache-extra-identifier input for matrix job cache separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ optional.
 - `cache-base` - Base branch/ref to save a warmup cache on. Other branches/refs will restore from
   this base.
 - `cache-target` - Name of the target profile to cache. Defaults to `debug`.
+- `cache-extra-identifier` - Additional identifier to include in cache key for matrix jobs or custom cache separation.
 - `channel` - Toolchain specification/channel to explicitly install.
 - `components` - Comma-separated list of additional components to install.
 - `inherit-toolchain` - Inherit all toolchain settings from the `rust-toolchain.toml` file. Defaults
@@ -117,6 +118,19 @@ be changed with the `cache-target` input, which defaults to `debug`.
   with:
     cache: false
     cache-target: release
+```
+
+For matrix jobs where the cache key would otherwise be identical, you can use `cache-extra-identifier` to ensure unique cache keys:
+
+```yaml
+strategy:
+  matrix:
+    os: [ubuntu-latest, windows-latest, macos-latest]
+    rust: [stable, beta]
+steps:
+  - uses: moonrepo/setup-rust@v1
+    with:
+      cache-extra-identifier: ${{ matrix.os }}-${{ matrix.rust }}
 ```
 
 The following optimizations and considerations are taken into account when caching:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
   cache-target:
     description: 'Name of the target profile to cache.'
     default: 'debug'
+  cache-extra-identifier:
+    description: 'Additional identifier to include in cache key for matrix jobs or custom cache separation.'
   channel:
     description: 'Toolchain specification/channel to explicitly install.'
   components:

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -96,6 +96,13 @@ export async function getPrimaryCacheKey() {
 			core.debug(`Hashing GITHUB_JOB = ${job}`);
 			hasher.update(job);
 		}
+
+		const extraIdentifier = core.getInput('cache-extra-identifier');
+
+		if (extraIdentifier) {
+			core.debug(`Hashing cache-extra-identifier = ${extraIdentifier}`);
+			hasher.update(extraIdentifier);
+		}
 	}
 
 	return `${getCachePrefixes()[0]}-${hasher.digest('hex')}`;


### PR DESCRIPTION
Fixes #32 

`GITHUB_JOB` is unfortunately not enough to discriminate between matrix branches, and there is no built-in identifier from github actions available in the environment variable to do so as far as I know.

This PR adds an optional input to allow users to customize the resulting cache key.

I've tested on my end, let me know if you have a particular procedure that needs to be performed, or if you have a better idea to solve the cache overriding in matrixes